### PR TITLE
added the ability to configure what key is used to retrieve the username from a UserInfo response

### DIFF
--- a/6.0/oauth/src/com/jaspersoft/jasperserver/ps/OAuth/OAuthUserDetailsServiceImpl.java
+++ b/6.0/oauth/src/com/jaspersoft/jasperserver/ps/OAuth/OAuthUserDetailsServiceImpl.java
@@ -45,6 +45,8 @@ import com.jaspersoft.jasperserver.multipleTenancy.MTUserDetails.TenantInfo;
 public class OAuthUserDetailsServiceImpl implements OAuthUserDetailsService {
     private static Log log = LogFactory.getLog(OAuthUserDetailsServiceImpl.class);
 
+    private String usernameKey = "name";
+
     @Override
     public UserDetails parseUserDetails(String jsonResponse) {
          if (jsonResponse != null) {
@@ -62,7 +64,7 @@ public class OAuthUserDetailsServiceImpl implements OAuthUserDetailsService {
 
             try {
                 myclaims = new JSONObject(jsonResponse);
-                username = myclaims.getString("name");
+                username = myclaims.getString(usernameKey);
                 displayname = myclaims.getString("name");
                 if(myclaims.has("roles")) {
                     roles = myclaims.getString("roles");
@@ -179,5 +181,13 @@ public class OAuthUserDetailsServiceImpl implements OAuthUserDetailsService {
         // check during testing
         wrappingUser.setExternallyDefined(true);
         return wrappingUser;
+    }
+
+    public String getUsernameKey() {
+        return usernameKey;
+    }
+
+    public void setUsernameKey(String usernameKey) {
+        this.usernameKey = usernameKey;
     }
 }


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/kmeadows1980/jasperserver/issues/5. It includes a new private attribute with a getter and a setter in OAuthUserDetailsServiceImpl, which allows users to configure what key is used to retrieve the username from a UserInfo response. It defaults to the value currently used ("name"), so is fully backwards compatible.

The implementation is rather simple and only covers the username attribute, but could be expanded to other attributes if it's desirable.

I have not updated the compiled binaries in /6.0/oauth/binaries/OAuth_module.jar, but could do that if it is preferrable.
